### PR TITLE
Fix torch version dependency

### DIFF
--- a/Infer.py
+++ b/Infer.py
@@ -12,7 +12,8 @@ import torch
 import soundfile as sf
 import librosa 
 from tqdm import tqdm
-from signal_processing import iSTFT_module_1_7
+from signal_processing import iSTFT_module
+from utils import is_pytorch_1_8
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 torch.set_default_tensor_type(torch.FloatTensor)
 WINDOW = torch.sqrt(torch.hann_window(1200,device=device) + 1e-8)
@@ -23,28 +24,32 @@ def infer(args):
     '''model'''
     model = DPModel(model_type='DPARN', device=device) # 定义模型
 
-
-    ''' load checkpoints'''
+    ''' load checkpoint'''
     checkpoint_DPARN = torch.load(args.check_dparn,map_location=device)
-    model.load_state_dict(checkpoint_DPARN['state_dict'])
+
+    '''load weights'''
+    model_state_dict = checkpoint_DPARN['state_dict']
+    if is_pytorch_1_8():
+        # loading these weights crashes in PyTorch >=1.8
+        model_state_dict.pop("process_model.intra_mha_list.0.MHA.out_proj.bias")
+        model_state_dict.pop("process_model.intra_mha_list.1.MHA.out_proj.bias")
+    model.load_state_dict(model_state_dict)
 
     model = model.to(device)
     model.eval()
 
     noisy_dir = args.noisy_dir
-    noisy_list = librosa.util.find_files(noisy_dir, ext='wav')
+    noisy_list = librosa.util.find_files(noisy_dir, ext=['wav', 'flac', 'mp3'])
     os.makedirs(args.saved_enhanced_dir, exist_ok=True)
 
     with torch.no_grad():
         for noisy_f in tqdm(noisy_list):
-            
-                
             noisy_s = sf.read(noisy_f)[0].astype('float32')
             noisy_s = torch.from_numpy(noisy_s.reshape((1,len(noisy_s)))).to(device)
             noisy_stft = torch.stft(noisy_s,1200,600,win_length=1200,window=WINDOW,center=True)
 
             enh_stft = model(noisy_stft)
-            enh_s = iSTFT_module_1_7(n_fft=1200, hop_length=600, win_length=1200,window=WINDOW,center = True,length = noisy_s.shape[-1])(enh_stft)
+            enh_s = iSTFT_module(n_fft=1200, hop_length=600, win_length=1200,window=WINDOW,center = True)(enh_stft)
             enh_s = enh_s[0,:].cpu().detach().numpy()
 
             enh_s = librosa.resample(enh_s, 48000, 16000)

--- a/Network_Training.py
+++ b/Network_Training.py
@@ -18,7 +18,7 @@ from Dataloader import Dataset, collate_fn
 from Modules import DPModel
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 torch.set_default_tensor_type(torch.FloatTensor)
-from signal_processing import iSTFT_module_1_7
+from signal_processing import iSTFT_module
 WINDOW = torch.sqrt(torch.hann_window(1200,device=device) + 1e-8)
 
 #------------------------warm up strategy------------------------
@@ -111,7 +111,7 @@ def train(end_epoch = 100):
 
             noisy_stft = torch.stft(noisy,1200,600,win_length=1200,window=WINDOW,center=True)
             enh_stft = model(noisy_stft)
-            enh_s = iSTFT_module_1_7(n_fft=1200, hop_length=600, win_length=1200,window=WINDOW,center = True,length = noisy.shape[-1])(enh_stft)
+            enh_s = iSTFT_module(n_fft=1200, hop_length=600, win_length=1200,window=WINDOW,center = True,length = noisy.shape[-1])(enh_stft)
 
             stft_loss, snr_loss = Loss(enh_s, clean) 
             stft_loss.backward()
@@ -135,7 +135,7 @@ def train(end_epoch = 100):
 
                 noisy_stft = torch.stft(noisy,1200,600,win_length=1200,window=WINDOW,center=True)
                 enh_stft = model(noisy_stft)
-                enh_s = iSTFT_module_1_7(n_fft=1200, hop_length=600, win_length=1200,window=WINDOW,center = True,length = noisy.shape[-1])(enh_stft)
+                enh_s = iSTFT_module(n_fft=1200, hop_length=600, win_length=1200,window=WINDOW,center = True,length = noisy.shape[-1])(enh_stft)
 
                 stft_loss, snr_loss = Loss(enh_s, clean)
                 valid_loss.append(stft_loss.cpu().detach().numpy())

--- a/signal_processing.py
+++ b/signal_processing.py
@@ -8,6 +8,11 @@ import torch
 from torch import nn
 import numpy as np
 import soundfile as sf
+import sys
+
+from utils import is_pytorch_1_8
+
+
 '''
 STFT module for torch>=1.7
 '''
@@ -48,80 +53,52 @@ class STFT_module(nn.Module):
              angle = torch.atan2(spec_complex[:, 1, :, :],spec_complex[:, 0, :, :])
              return torch.stack([mag,angle],1)
 
-'''
-iSTFT module for torch >= 1.8
-'''
-class iSTFT_module_1_8(nn.Module):
-    
-    def __init__(self, n_fft, hop_length, win_length, length, center = False, window = None, mode = 'real_imag',device = 'cpu'):
-        super(iSTFT_module_1_8, self).__init__()
+
+class iSTFT_module(nn.Module):
+
+    def __init__(self, n_fft, hop_length, win_length, center=False, window=None, mode='real_imag',
+                 device='cpu'):
+        super(iSTFT_module, self).__init__()
         self.mode = mode
         self.n_fft = n_fft
         self.hop_length = hop_length
         self.win_length = win_length
-        self.length = length
-        self.center = center
-        self.window = window
-        if center:
-            self.padding_num = int((self.win_length / 2 ) // (self.hop_length) * self.hop_length)
-        else:
-            self.padding_num = 0
-            
-        # if not window:
-        #     self.window = torch.sqrt(torch.hann_window(self.win_length)+1e-8).to(device)
-        
-    def forward(self, x):
-        '''
-        return: batchsize, 2, Time, Freq
-        '''
-        length = self.win_length + self.hop_length * (x.shape[-2] - 1)
-        spec_complex = x[:,0] + x[:,1] * 1j
-        frame_chunks = torch.fft.irfft(spec_complex)
-        frame_chunks = frame_chunks * self.window
-        if self.center:
-            s = torch.nn.Fold(output_size=[length,1], kernel_size=[self.win_length,1],stride=[self.hop_length,1])(frame_chunks.permute([0,2,1]))[:,0,self.padding_num:-self.padding_num,0] 
-        else:
-            s = torch.nn.Fold(output_size=[length,1], kernel_size=[self.win_length,1],stride=[self.hop_length,1])(frame_chunks.permute([0,2,1]))[:,0,:,0] 
-        
-        return s
-    
-'''
-iSTFT module for torch <= 1.7
-'''
-class iSTFT_module_1_7(nn.Module):
-    
-    def __init__(self, n_fft, hop_length, win_length, length, center = False, window = None, mode = 'real_imag',device = 'cpu'):
-        super(iSTFT_module_1_7, self).__init__()
-        self.mode = mode
-        self.n_fft = n_fft
-        self.hop_length = hop_length
-        self.win_length = win_length
-        self.length = length
         self.center = center
         if center:
-            self.padding_num = int((self.win_length / 2 ) // (self.hop_length) * self.hop_length)
+            self.padding_num = int((self.win_length / 2) // (self.hop_length) * self.hop_length)
         else:
             self.padding_num = 0
-            
-        if window == None:
-            self.window = torch.sqrt(torch.hann_window(self.win_length)+1e-8).to(device)
+
+        if window is None:
+            self.window = torch.sqrt(torch.hann_window(self.win_length) + 1e-8).to(device)
         else:
             self.window = window
-        
+
+        # torch.irfft() is not available from pytorch 1.8 on
+        self.pytorch_version_1_8 = is_pytorch_1_8()
+
     def forward(self, x):
         '''
         return: batchsize, 2, Time, Freq
         '''
         length = self.win_length + self.hop_length * (x.shape[-2] - 1)
-        # bs,T,F,2 --> bs,T,F*2
-        frame_chunks = torch.irfft(x.permute([0,2,3,1]),signal_ndim=1,signal_sizes=[self.win_length])
+        if self.pytorch_version_1_8:
+            spec_complex = x[:, 0] + x[:, 1] * 1j
+            frame_chunks = torch.fft.irfft(spec_complex)
+        else:
+            # bs,T,F,2 --> bs,T,F*2
+            frame_chunks = torch.irfft(x.permute([0, 2, 3, 1]), signal_ndim=1, signal_sizes=[self.win_length])
+
         frame_chunks = frame_chunks * self.window
         if self.center:
-            s = torch.nn.Fold(output_size=[length,1], kernel_size=[self.win_length,1],stride=[self.hop_length,1])(frame_chunks.permute([0,2,1]))[:,0,self.padding_num:-self.padding_num,0] 
+            s = torch.nn.Fold(output_size=[length, 1], kernel_size=[self.win_length, 1], stride=[self.hop_length, 1])(
+                frame_chunks.permute([0, 2, 1]))[:, 0, self.padding_num:-self.padding_num, 0]
         else:
-            s = torch.nn.Fold(output_size=[length,1], kernel_size=[self.win_length,1],stride=[self.hop_length,1])(frame_chunks.permute([0,2,1]))[:,0,:,0] 
-        
+            s = torch.nn.Fold(output_size=[length, 1], kernel_size=[self.win_length, 1], stride=[self.hop_length, 1])(
+                frame_chunks.permute([0, 2, 1]))[:, 0, :, 0]
+
         return s
+
 
 def ola(inputs, win_size, win_shift):
     nframes = inputs.shape[-2]
@@ -141,11 +118,19 @@ if __name__ == '__main__':
     '''
     if center, the STFT module will pad (win_length // 2 // hop_length) frames on both sides of the original sequence
     '''
-    audio_test_dir = '/data/hdd0/zhongshu.hou/Torch_DPCRN/Valid_enh_FTCRN/noisy/nsy12.wav'
-    au, _ = sf.read(audio_test_dir)
+    # read audio file from STDIN if it was spplied
+    if len(sys.argv) > 1:
+        audio_file = sys.argv[1]
+    else:
+        audio_file = '/data/hdd0/zhongshu.hou/Torch_DPCRN/Valid_enh_FTCRN/noisy/nsy12.wav'
+
+    au, _ = sf.read(audio_file)
     # au = au[:-3]
     a = torch.from_numpy(au).reshape([1,len(au)])
     spec = STFT_module(n_fft=1200, hop_length=600, win_length=1200, center = True, normalized = False, window = torch.hann_window, )(a)
-    s = iSTFT_module_1_8(n_fft=1200, hop_length=600, win_length=1200,center = True,length = a.shape[-1])(spec)
+    s = iSTFT_module(n_fft=1200, hop_length=600, win_length=1200,center = True,length = a.shape[-1])(spec)
 
-    print(torch.max(s - a))
+    # due to buffering s may have a slightly different length than a
+    max_sample = np.min([s.shape[-1], a.shape[-1]])
+
+    print(torch.max(s[:, :max_sample] - a[:, :max_sample]))

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,7 @@
+import torch
+
+
+def is_pytorch_1_8():
+    """ Returns True if PyTorch is >= 1.8.
+    """
+    return int(str(torch.__version__).split(".")[1]) >= 8


### PR DESCRIPTION
# Description

Previously the code base had a hardcoded dependency on the PyTorch version. More precisely, PyTorch >= 1.8 required

- deleting 2 fields from the model state dict in [Infer.py](https://github.com/Qinwen-Hu/dparn/blob/main/Infer.py)
- selecting the correct iSTFT module manually (either `iSTFT_module_1_7` or `iSTFT_module_1_8`)

This pull request fixes the problem by deriving the PyTorch version automatically and fixing the 2 issues above where needed.

Fixes #5 #3 

## List of changes

- add `utils.py`
- merge `iSTFT_module_1_7` and `iSTFT_module_1_8` into single class `iSTFT_module`
  - adapt all imports for this class
  - remove the mandatory `length` arg for `iSTFT_module.__init__()` as it was unused
- for PyTorch >=1.8 delete fields from model state dict in `Infer.py` which made the script crash
- fix `signal_processing.py:__main__`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With my local conda environment which uses PyTorch v1.10.1 and all other packages required and the [pretrained checkpoint](https://github.com/Qinwen-Hu/dparn/blob/main/checkpoint_DPARN_trained_on_DNS4.pth). Please note that I only tested `Infer.py` and not `NetworkTraining.py`.